### PR TITLE
Fixed a bug with commas, all tests are now passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Human Interval
-Human readable interval parser for Node.js/the Browser.
+Human readable interval parser and formatter for Node.js/the browser.
 
 Heavily inspired by
 [matthewmueller/date](http://github.com/matthewmueller/date).
@@ -12,7 +12,20 @@ var humanInterval = require('human-interval');
 
 setTimeout(function() {
   // Do something crazy!
-}, humanInterval('three minutes'));
+}, humanInterval.human('three minutes'));
+
+```
+
+```js
+var humanInterval = require('human-interval');
+
+var timeout = 124000;
+
+setTimeout(function() {
+  // Do something crazy!
+}, timeout);
+
+console.log("The action will be taken in " + humanInterval.machine(timeout));
 
 ```
 
@@ -21,10 +34,10 @@ setTimeout(function() {
 humanInterval understands all of the following examples:
 
 ```js
-humanInterval('one minute');
-humanInterval('1.5 minutes');
-humanInterval('3 days and 4 hours');
-humanInterval('3 days, 4 hours and 36 seconds');
+humanInterval.human('one minute');
+humanInterval.human('1.5 minutes');
+humanInterval.human('3 days and 4 hours');
+humanInterval.human('3 days, 4 hours and 36 seconds');
 ```
 
 ## The full list
@@ -40,6 +53,8 @@ Human Interval supports the following units
 - `weeks`
 - `months` -- assumes 30 days
 - `years` -- assumes 365 days
+
+You can access and modify this list through `humanInterval.units`. For example, you could do this to support customized units, or to localize names.
 
 ### Wordy Numbers
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var humanInterval = module.exports = function humanInterval(time) {
   time = swapLanguageToDecimals(time);
   time = time.replace(/(second|minute|hour|day|week|month|year)s?(?! ?(s )?and |s?$)/, '$1,');
   return time.split(/and|,/).reduce(function(sum, group) {
-    return sum + processUnits(group);
+    return sum + (group != "" ? processUnits(group) : 0);
   }, 0);
 };
 

--- a/index.js
+++ b/index.js
@@ -1,25 +1,79 @@
-var humanInterval = module.exports = function humanInterval(time) {
-  if(!time) return time;
-  if(typeof time == 'number') return time;
-  time = swapLanguageToDecimals(time);
-  time = time.replace(/(second|minute|hour|day|week|month|year)s?(?! ?(s )?and |s?$)/, '$1,');
-  return time.split(/and|,/).reduce(function(sum, group) {
-    return sum + (group != "" ? processUnits(group) : 0);
-  }, 0);
-};
+var humanInterval = module.exports = {
+  human: function(time) {
+    if(!time) return time;
+    if(typeof time == 'number') return time;
+    time = swapLanguageToDecimals(time);
+    time = time.replace(/(second|minute|hour|day|week|month|year)s?(?! ?(s )?and |s?$)/, '$1,');
+    return time.split(/and|,/).reduce(function(sum, group) {
+      return sum + (group != "" ? processUnits(group) : 0);
+    }, 0);
+  },
+  machine: function(time) {
+    var temp, description = "";
+    if (!time) return time;
+    for (name in humanInterval.units) {
+      temp = collectUnit(time, humanInterval.units[name], name);
+      description += temp[0] + (temp[0] == "" ? "" : ", ");
+      time = temp[1]; // New time
+    }
+    description = description.slice(0, -2); // Removes the spurious comma-space
+    return description;
+  },
+  languageMap: {
+    'one': 1,
+    'two': 2,
+    'three': 3,
+    'four': 4,
+    'five': 5,
+    'six': 6,
+    'seven': 7,
+    'eight': 8,
+    'nine': 9,
+    'ten': 10
+  },
+  reverseLanguageMap: {
+    1: 'one',
+    2: 'two',
+    3: 'three',
+    4: 'four',
+    5: 'five',
+    6: 'six',
+    7: 'seven',
+    8: 'eight',
+    9: 'nine',
+    10: 'ten'
+  },
+  units: {
+    "year":   365*24*60*60*1000,
+    "month":  30*24*60*60*1000,
+    "week":   7*24*60*60*1000,
+    "day":    24*60*60*1000,
+    "hour":   60*60*1000,
+    "minute": 60*1000,
+    "second": 1000
+  }
+}
 
-humanInterval.languageMap = {
-  'one': 1,
-  'two': 2,
-  'three': 3,
-  'four': 4,
-  'five': 5,
-  'six': 6,
-  'seven': 7,
-  'eight': 8,
-  'nine': 9,
-  'ten': 10
-};
+function collectUnit(time, unit, name) {
+  /* Returns an array, the first element of which is a sentence
+   * representing the units collected and the second element of
+   * which is the time after collecting the unit.
+   */
+  units = Math.floor(time / unit);
+  if (units == 0) {
+    description = "";
+    newTime = time;
+  } else {
+    if (units > 10) {
+      description = units;
+    } else {
+      description = humanInterval.reverseLanguageMap[units];
+    }
+    description += " " + name + (units > 1 ? "s" : "");
+    newTime = time - units*unit;
+  }
+  return [description, newTime];
+}
 
 function swapLanguageToDecimals(time) {
   var language = humanInterval.languageMap;

--- a/test/human-interval.js
+++ b/test/human-interval.js
@@ -3,69 +3,116 @@ var expect = require('expect.js'),
 
 describe('Human Interval', function() {
   it("returns the number when given a number", function() {
-    expect(humanInterval(5000)).to.be(5000);
+    expect(humanInterval.human(5000)).to.be(5000);
   });
 
   it("returns undefined when given undefined", function() {
-    expect(humanInterval(undefined)).to.be(undefined);
+    expect(humanInterval.human(undefined)).to.be(undefined);
   });
 
   it('does not require a number', function() {
-      expect(humanInterval('week')).to.be(7 * 86400000);
+      expect(humanInterval.human('week')).to.be(7 * 86400000);
   });
 
   describe('basic units', function() {
     it('understands seconds', function() {
-      expect(humanInterval('1 second')).to.be(1000);
+      expect(humanInterval.human('1 second')).to.be(1000);
     });
     it('understands minutes', function() {
-      expect(humanInterval('1 minute')).to.be(60000);
+      expect(humanInterval.human('1 minute')).to.be(60000);
     });
     it('understands hours', function() {
-      expect(humanInterval('1 hour')).to.be(3600000);
+      expect(humanInterval.human('1 hour')).to.be(3600000);
     });
     it('understands days', function() {
-      expect(humanInterval('1 day')).to.be(86400000);
+      expect(humanInterval.human('1 day')).to.be(86400000);
     });
     it('understands weeks', function() {
-      expect(humanInterval('1 week')).to.be(7 * 86400000);
+      expect(humanInterval.human('1 week')).to.be(7 * 86400000);
     });
     it('understands months', function() {
-      expect(humanInterval('1 month')).to.be(30 * 86400000);
+      expect(humanInterval.human('1 month')).to.be(30 * 86400000);
     });
     it('understands years', function() {
-      expect(humanInterval('1 year')).to.be(31536000000);
+      expect(humanInterval.human('1 year')).to.be(31536000000);
     });
   });
 
   describe("basic numbers", function() {
     it("understands numbers", function() {
-      expect(humanInterval('2 seconds')).to.be(2000);
+      expect(humanInterval.human('2 seconds')).to.be(2000);
     });
 
     it("understands decimals", function() {
-      expect(humanInterval('2.5 seconds')).to.be(2500);
+      expect(humanInterval.human('2.5 seconds')).to.be(2500);
     });
   });
 
   describe("english numbers", function() {
     it("understands numbers", function() {
-      expect(humanInterval("two seconds")).to.be(2000);
+      expect(humanInterval.human("two seconds")).to.be(2000);
     });
   });
 
   describe("mixes", function() {
     it("works with long numbers", function() {
-      expect(humanInterval('3 minutes and 30 seconds')).to.be(210000);
+      expect(humanInterval.human('3 minutes and 30 seconds')).to.be(210000);
     });
 
     it("works with mixed units", function() {
-      expect(humanInterval('3 minutes and 30 seconds')).to.be(210000);
+      expect(humanInterval.human('3 minutes and 30 seconds')).to.be(210000);
     });
 
     it("works with mixed time expressions", function() {
-      expect(humanInterval('three minutes and 30 seconds')).to.be(210000);
-      expect(humanInterval('three minutes 30 seconds')).to.be(210000);
+      expect(humanInterval.human('three minutes and 30 seconds')).to.be(210000);
+      expect(humanInterval.human('three minutes 30 seconds')).to.be(210000);
+    });
+  });
+});
+
+
+describe('Machine Interval', function() {
+
+  it("returns undefined when given undefined", function() {
+    expect(humanInterval.machine(undefined)).to.be(undefined);
+  });
+
+  describe('basic units', function() {
+    it('outputs seconds', function() {
+      expect(humanInterval.machine(1000)).to.be('one second');
+    });
+    it('outputs minutes', function() {
+      expect(humanInterval.machine(60000)).to.be('one minute');
+    });
+    it('outputs hours', function() {
+      expect(humanInterval.machine(3600000)).to.be('one hour');
+    });
+    it('outputs days', function() {
+      expect(humanInterval.machine(86400000)).to.be('one day');
+    });
+    it('outputs weeks', function() {
+      expect(humanInterval.machine(7 * 86400000)).to.be('one week');
+    });
+    it('outputs months', function() {
+      expect(humanInterval.machine(30 * 86400000)).to.be('one month');
+    });
+    it('outputs years', function() {
+      expect(humanInterval.machine(31536000000)).to.be('one year');
+    });
+  });
+
+  describe("basic numbers", function() {
+    it("outputs numbers", function() {
+      expect(humanInterval.machine(2000)).to.be('two seconds');
+      expect(humanInterval.machine(
+        10*humanInterval.units.year  +
+        9*humanInterval.units.month +
+        3*humanInterval.units.week  +
+        2*humanInterval.units.day   +
+        8*humanInterval.units.hour  +
+        7*humanInterval.units.minute+
+        5*humanInterval.units.second
+      )).to.be('ten years, nine months, three weeks, two days, eight hours, seven minutes, five seconds');
     });
   });
 });


### PR DESCRIPTION
The module had a bug where it would fail on strings like "1 hour, 8 minutes ago", because of the comma. This happened because it called processUnits on an empty string, so I just added a check that skips processUnits when the string is null.
