### PR TITLE
Fixed a bug with commas, all tests are now passing

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var humanInterval = module.exports = function humanInterval(time) {
   time = swapLanguageToDecimals(time);
   time = time.replace(/(second|minute|hour|day|week|month|year)s?(?! ?(s )?and |s?$)/, '$1,');
   return time.split(/and|,/).reduce(function(sum, group) {
-    return sum + processUnits(group);
+    return sum + (group != "" ? processUnits(group) : 0);
   }, 0);
 };
 


### PR DESCRIPTION
The module had a bug where it would fail on strings like `1 hour, 8 minutes ago`, because of the comma. This happened because it called `processUnits` on an empty string, so I just added a check that skips `processUnits` when the string is null.
