### PR TITLE
Cleanup syntax

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,29 @@
+env:
+    node: true
+
+rules:
+    brace-style: [2, '1tbs']
+    comma-style: [2, 'last']
+    default-case: 0
+    guard-for-in: 2
+    no-floating-decimal: 2
+    no-nested-ternary: 2
+    no-multi-spaces: 2
+    no-underscore-dangle: 0
+    no-shadow: 0
+    no-use-before-define: [1, 'nofunc']
+    new-cap: 0
+    radix: 2
+    quotes: [2, 'single']
+    space-before-function-paren: [2, 'never']
+    keyword-spacing: [2, { 'after': true }]
+    spaced-comment: [2, 'always', { exceptions: ['-']}]
+    strict: [2, 'never']
+    valid-jsdoc: [1, { prefer: { 'return': 'returns'}}]
+    wrap-iife: 2
+    comma-dangle: 0
+    no-mixed-requires: [0, false]
+
+globals:
+    'describe': true
+    'it': true

--- a/index.js
+++ b/index.js
@@ -1,12 +1,19 @@
-var humanInterval = module.exports = function humanInterval (time) {
-  if (!time) return time
-  if (typeof time === 'number') return time
-  time = swapLanguageToDecimals(time)
-  time = time.replace(/(second|minute|hour|day|week|month|year)s?(?! ?(s )?and |s?$)/, '$1,')
-  return time.split(/and|,/).reduce(function (sum, group) {
-    return sum + (group !== '' ? processUnits(group) : 0)
-  }, 0)
-}
+var humanInterval = module.exports = function humanInterval(time) {
+  if (!time) {
+    return time;
+  }
+
+  if (typeof time === 'number') {
+    return time;
+  }
+
+  time = swapLanguageToDecimals(time);
+  time = time.replace(/(second|minute|hour|day|week|month|year)s?(?! ?(s )?and |s?$)/, '$1,');
+
+  return time.split(/and|,/).reduce(function(sum, group) {
+    return sum + (group !== '' ? processUnits(group) : 0);
+  }, 0);
+};
 
 humanInterval.languageMap = {
   'one': 1,
@@ -19,47 +26,63 @@ humanInterval.languageMap = {
   'eight': 8,
   'nine': 9,
   'ten': 10
-}
+};
 
-function swapLanguageToDecimals (time) {
-  var language = humanInterval.languageMap
-  var languageMapRegex = new RegExp('(' + Object.keys(language).join('|') + ')', 'g')
-  var matches = time.match(languageMapRegex)
-  if (!matches) return time
-
-  matches.forEach(function (match) {
-    var matchStr = language[match] > 1 ? language[match] : language[match].toString().slice(1)
-    time = time.replace(match, matchStr)
-  })
-  return time
-}
-
-function processUnits (time) {
-  var unit
-  var num = parseFloat(time, 10)
-  var unitMatch = time.match(/(second|minute|hour|day|week|month|year)s?/)
-  if (unitMatch) {
-    unit = unitMatch[1]
-  } else {
-    throw new Error('Unrecognised time unit. Use second(s), minute(s), hour(s), day(s), week(s), month(s), or year(s).')
+function swapLanguageToDecimals(time) {
+  var language = humanInterval.languageMap;
+  var languageMapRegex = new RegExp('(' + Object.keys(language).join('|') + ')', 'g');
+  var matches = time.match(languageMapRegex);
+  if (!matches) {
+    return time;
   }
-  if (!num) num = 1
+
+  matches.forEach(function(match) {
+    var matchStr = language[match] > 1 ? language[match] : language[match].toString().slice(1);
+    time = time.replace(match, matchStr);
+  });
+
+  return time;
+}
+
+function processUnits(time) {
+  var unit;
+  var num = parseFloat(time, 10);
+
+  if (!num) {
+    num = 1;
+  }
+
+  var unitMatch = time.match(/(second|minute|hour|day|week|month|year)s?/);
+
+  if (unitMatch) {
+    unit = unitMatch[1];
+  } else {
+    throw new Error('Unrecognised time unit. Use second(s), minute(s), hour(s), day(s), week(s), month(s), or year(s).');
+  }
 
   switch (unit) {
-    case 'second': unit = 1000
-      break
-    case 'minute': unit = 1000 * 60
-      break
-    case 'hour': unit = 1000 * 60 * 60
-      break
-    case 'day': unit = 1000 * 60 * 60 * 24
-      break
-    case 'week': unit = 1000 * 60 * 60 * 24 * 7
-      break
-    case 'month': unit = 1000 * 60 * 60 * 24 * 30
-      break
-    case 'year': unit = 1000 * 60 * 60 * 24 * 365
-      break
+    case 'second':
+      unit = 1000;
+      break;
+    case 'minute':
+      unit = 1000 * 60;
+      break;
+    case 'hour':
+      unit = 1000 * 60 * 60;
+      break;
+    case 'day':
+      unit = 1000 * 60 * 60 * 24;
+      break;
+    case 'week':
+      unit = 1000 * 60 * 60 * 24 * 7;
+      break;
+    case 'month':
+      unit = 1000 * 60 * 60 * 24 * 30;
+      break;
+    case 'year':
+      unit = 1000 * 60 * 60 * 24 * 365;
+      break;
   }
-  return unit * num
+
+  return unit * num;
 }

--- a/index.js
+++ b/index.js
@@ -37,8 +37,12 @@ function swapLanguageToDecimals (time) {
 function processUnits (time) {
   var unit
   var num = parseFloat(time, 10)
-  if (time.match(/(second|minute|hour|day|week|month|year)s?/) !== null) unit = time.match(/(second|minute|hour|day|week|month|year)s?/)[1]
-  else unit = undefined
+  var unitMatch = time.match(/(second|minute|hour|day|week|month|year)s?/)
+  if (unitMatch) {
+    unit = unitMatch[1]
+  } else {
+    throw new Error('Unrecognised time unit. Use second(s), minute(s), hour(s), day(s), week(s), month(s), or year(s).')
+  }
   if (!num) num = 1
 
   switch (unit) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Human readable time measurements",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "eslint test/* index.js && mocha --reporter spec --timeout 3500"
   },
   "repository": {
     "type": "git",
@@ -21,6 +21,8 @@
     "url": "https://github.com/rschmukler/human-interval/issues"
   },
   "devDependencies": {
-    "expect.js": "~0.2.0"
+    "eslint": "~4.3.0",
+    "expect.js": "~0.3.1",
+    "mocha": "~3.4.2"
   }
 }

--- a/test/human-interval.js
+++ b/test/human-interval.js
@@ -2,16 +2,16 @@ var expect = require('expect.js'),
     humanInterval = require('../index.js');
 
 describe('Human Interval', function() {
-  it("returns the number when given a number", function() {
+  it('returns the number when given a number', function() {
     expect(humanInterval(5000)).to.be(5000);
   });
 
-  it("returns undefined when given undefined", function() {
+  it('returns undefined when given undefined', function() {
     expect(humanInterval(undefined)).to.be(undefined);
   });
 
   it('does not require a number', function() {
-      expect(humanInterval('week')).to.be(7 * 86400000);
+    expect(humanInterval('week')).to.be(7 * 86400000);
   });
 
   describe('basic units', function() {
@@ -38,32 +38,32 @@ describe('Human Interval', function() {
     });
   });
 
-  describe("basic numbers", function() {
-    it("understands numbers", function() {
+  describe('basic numbers', function() {
+    it('understands numbers', function() {
       expect(humanInterval('2 seconds')).to.be(2000);
     });
 
-    it("understands decimals", function() {
+    it('understands decimals', function() {
       expect(humanInterval('2.5 seconds')).to.be(2500);
     });
   });
 
-  describe("english numbers", function() {
-    it("understands numbers", function() {
-      expect(humanInterval("two seconds")).to.be(2000);
+  describe('english numbers', function() {
+    it('understands numbers', function() {
+      expect(humanInterval('two seconds')).to.be(2000);
     });
   });
 
-  describe("mixes", function() {
-    it("works with long numbers", function() {
+  describe('mixes', function() {
+    it('works with long numbers', function() {
       expect(humanInterval('3 minutes and 30 seconds')).to.be(210000);
     });
 
-    it("works with mixed units", function() {
+    it('works with mixed units', function() {
       expect(humanInterval('3 minutes and 30 seconds')).to.be(210000);
     });
 
-    it("works with mixed time expressions", function() {
+    it('works with mixed time expressions', function() {
       expect(humanInterval('three minutes and 30 seconds')).to.be(210000);
       expect(humanInterval('three minutes 30 seconds')).to.be(210000);
     });

--- a/test/human-interval.js
+++ b/test/human-interval.js
@@ -68,4 +68,11 @@ describe('Human Interval', function() {
       expect(humanInterval('three minutes 30 seconds')).to.be(210000);
     });
   });
+
+  describe('Error handling', function() {
+    it('throw error on unrecognised time unit', function() {
+      expect(humanInterval).withArgs('3 unrecognised').to.throwError();
+      expect(humanInterval).withArgs('3 seconds').to.not.throwError();
+    });
+  });
 });


### PR DESCRIPTION
- Throw error on unrecognised time unit (adds test for this)
- Cleanup JS syntax for readability and consistency. 
- Add Eslint to guard syntax, ruleset is similar to [Agenda eslint config](https://github.com/agenda/agenda/blob/master/.eslintrc)

Requires https://github.com/rschmukler/human-interval/pull/11 to go in first as this PR requires newer Expect.js than `master` branch currently has.