### PR TITLE
Refactor module to use node-numbered instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,7 @@ Human Interval supports the following units
 
 ### Wordy Numbers
 
-Human Interval supports numbers up to ten being written out in English. If you
-want to extend it, you can do so by adding more keys to the language map.
-Alternatively you could add support for alternative languages.
-
-```js
-const humanInterval = require('human-interval');
-humanInterval.languageMap['one-hundred'] = 100
-
-// Adds support for the following:
-humanInterval('one-hundred and fifty seconds') // returns 150000
-```
+Human Interval supports English numbers being written out in English by using [node-numbered](https://github.com/blakeembrey/node-numbered).
 
 # License
 [The MIT License](LICENSE.md)

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "envs": [
         "node"
     ]
+  },
+  "dependencies": {
+    "numbered": "^1.1.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -19,5 +19,8 @@ test('understands years', macro, '1 year', 31536000000);
 test('understands numbers', macro, '2 seconds', 2000);
 test('understands decimals', macro, '2.5 seconds', 2500);
 test('understands english numbers', macro, 'two seconds', 2000);
+test('understands negative numbers', macro, '-2 seconds', -2000);
 test('works with mixed units', macro, '3 minutes and 30 seconds', 210000);
 test('works with mixed time expressions', macro, ['three minutes and 30 seconds', 'three minutes 30 seconds'], 210000);
+test('Understands 2 digit english numbers', macro, 'thirty three seconds', 33000);
+test('mix units + multi digit english numbers', macro, 'hundred and three seconds and twelve minutes', 823000);


### PR DESCRIPTION
Note that this removes the `languageMap` support because it doesn't make sense and a quick search on Github didn't show anybody using it in an open source package. You can just release a semver major version.

However if you don't agree with this, we could easily add it back and emulate it.

Another to note that node-numbered only supports English numbers. I was thinking to support this people could provide their own English number parser(something that does exactly what [`numbered.parse`](https://github.com/blakeembrey/node-numbered) does as an argument. We could try to extend `node-numbered` but I'm sure it'll never be good enough to support all languages with the same amount of code, so letting people having their own parser specific for their language makes the package more usable.

Closes #9 