### PR TITLE
Drop support for Node.js v4 and v5 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
   - "6"
   - "7"
   - "8"


### PR DESCRIPTION
I noticed #19 was failing because of this.