### PR TITLE
fix: Removed incorrect second parameter in parseFloat function call

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const processUnits = time => {
     return undefined;
   }
 
-  const num = parseFloat(time, 10) || 1;
+  const num = parseFloat(time) || 1;
   const unit = time.match(/(second|minute|hour|day|week|month|year)s?/)[1];
 
   return units[unit] * num;


### PR DESCRIPTION
- parseFloat in javascript does not have a second parameter for specifying radix
- src (https://www.w3schools.com/jsref/jsref_parsefloat.asp)
- only parseInt has second parameter for specifying radix (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt)
- changed order of import in test.js to avoid the error -  `import should occur before import of ava  import/order`