### PR TITLE
Refactor human interval using node-numbered package

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Human readable interval parser for Javascript.
 Heavily inspired by
 [matthewmueller/date](http://github.com/matthewmueller/date).
 
+This package converts words written in english to numbers by using [node-numbered](https://github.com/blakeembrey/node-numbered).
+
 
 ## Example Usage
 
@@ -21,10 +23,12 @@ setTimeout(() => {
 Human Interval understands all of the following examples:
 
 ```js
+humanInterval('minute');
 humanInterval('one minute');
 humanInterval('1.5 minutes');
 humanInterval('3 days and 4 hours');
 humanInterval('3 days, 4 hours and 36 seconds');
+humanInterval('4 months, 3 days, 5 hours and forty-five seconds');
 ```
 
 ## The full list
@@ -43,7 +47,27 @@ Human Interval supports the following units
 
 ### Wordy Numbers
 
-Human Interval supports English numbers being written out in English by using [node-numbered](https://github.com/blakeembrey/node-numbered).
+Human Interval supports numbers being written out in English words.
+
+```js
+humanInterval('five minutes');
+```
+
+### Hyphenated Numbers
+
+Human Interval supports hyphenated numbers.
+
+```js
+humanInterval('twenty-five seconds');
+```
+
+### Negative Numbers
+
+Human Interval supports negative numbers if the time starts with a `-` symbol immediately followed by a number.
+
+```js
+humanInterval('-2 minutes');
+```
 
 # License
 [The MIT License](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -43,17 +43,7 @@ Human Interval supports the following units
 
 ### Wordy Numbers
 
-Human Interval supports numbers up to ten being written out in English. If you
-want to extend it, you can do so by adding more keys to the language map.
-Alternatively you could add support for alternative languages.
-
-```js
-const humanInterval = require('human-interval');
-humanInterval.languageMap['one-hundred'] = 100
-
-// Adds support for the following:
-humanInterval('one-hundred and fifty seconds') // returns 150000
-```
+Human Interval supports English numbers being written out in English by using [node-numbered](https://github.com/blakeembrey/node-numbered).
 
 # License
 [The MIT License](LICENSE.md)

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const humanInterval = time => {
     return time;
   }
 
-  let result = 0;
+  let result = NaN;
 
   time = time.replace(/([^a-z0-9.-]|and)+/g, ' ');
 
@@ -34,6 +34,10 @@ const humanInterval = time => {
       if (isNaN(number)) {
         number = numbered.parse(matchedNumber);
       }
+    }
+
+    if (isNaN(result)) {
+      result = 0;
     }
 
     result += number * unit;

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "envs": [
         "node"
     ]
+  },
+  "dependencies": {
+    "numbered": "^1.1.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -19,5 +19,8 @@ test('understands years', macro, '1 year', 31536000000);
 test('understands numbers', macro, '2 seconds', 2000);
 test('understands decimals', macro, '2.5 seconds', 2500);
 test('understands english numbers', macro, 'two seconds', 2000);
+test('understands negative numbers', macro, '-2 seconds', -2000);
 test('works with mixed units', macro, '3 minutes and 30 seconds', 210000);
 test('works with mixed time expressions', macro, ['three minutes and 30 seconds', 'three minutes 30 seconds'], 210000);
+test('Understands 2 digit english numbers', macro, 'thirty three seconds', 33000);
+test('mix units + multi digit english numbers', macro, 'hundred and three seconds and twelve minutes', 823000);

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
-const humanInterval = require('.');
 const test = require('ava');
+const humanInterval = require('.');
 
 const macro = (t, inputs, expected) => {
   inputs = Array.isArray(inputs) ? inputs : [inputs];
@@ -15,21 +15,110 @@ units.week = units.day * 7;
 units.month = units.day * 30;
 units.year = units.day * 365;
 
-test('returns the number when given a number', macro, 5000, 5000);
-test('returns undefined when given undefined', macro, undefined, undefined);
-test('does not require a number', macro, 'week', units.week);
-test('understands seconds', macro, '1 second', units.second);
-test('understands minutes', macro, '1 minute', units.minute);
-test('understands hours', macro, '1 hour', units.hour);
-test('understands days', macro, '1 day', units.day);
-test('understands weeks', macro, '1 week', units.week);
-test('understands months', macro, '1 month', units.month);
-test('understands years', macro, '1 year', units.year);
-test('understands numbers', macro, '2 seconds', 2 * units.second);
-test('understands decimals', macro, '2.5 seconds', 2.5 * units.second);
-test('understands english numbers', macro, 'two seconds', 2 * units.second);
-test('understands negative numbers', macro, '-2 seconds', -2 * units.second);
-test('works with mixed units', macro, '3 minutes and 30 seconds', (3 * units.minute) + (30 * units.second));
-test('works with mixed time expressions', macro, ['three minutes and 30 seconds', 'three minutes 30 seconds'], (3 * units.minute) + (30 * units.second));
+const timeUnits = [
+  'second',
+  'minute',
+  'hour',
+  'day',
+  'week',
+  'month',
+  'year'
+];
+
+const englishNumbers = [
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+  'ten'
+];
+
+// Invalid values:
+test('Returns undefined when given undefined', macro, undefined, undefined);
+test('Returns null when given null', macro, null, null);
+test('Returns empty string when given empty string', macro, '', '');
+test('Returns NaN when given unknown string', macro, 'foobar', NaN);
+
+// Single values
+test('Returns the number when given a number', macro, 5000, 5000);
+test('Understands numbers', macro, '2 seconds', 2 * units.second);
+test('Understands decimals', macro, '2.5 seconds', 2.5 * units.second);
+test('Understands long decimals', macro, '2.5555 seconds', 2.5555 * units.second);
+
+// Understands time base units without numbers
+// i.e. "second === 1000"
+timeUnits.forEach(unit => {
+  test(
+    'Understands "' + unit + '" without number',
+    macro,
+    unit,
+    Number(units[unit])
+  );
+});
+
+// Understands time base units in singular
+// i.e. "1 second === 1000"
+timeUnits.forEach(unit => {
+  test(
+    'Understands "1 ' + unit + '"',
+    macro,
+    '1 ' + unit,
+    Number(units[unit])
+  );
+});
+
+// Understands time base units in plural
+// i.e. "2 seconds === 2000"
+timeUnits.forEach(unit => {
+  test(
+    'Understands ' + unit + 's in plural',
+    macro,
+    '2 ' + unit + 's',
+    2 * Number(units[unit])
+  );
+});
+
+// Understands time base units in decimals values
+// i.e. "1.5 seconds === 1500"
+timeUnits.forEach(unit => {
+  test(
+    'Understands ' + unit + 's in decimals',
+    macro,
+    '1.5 ' + unit + 's',
+    1.5 * Number(units[unit])
+  );
+});
+
+// English numbers
+// i.e. "one second === 1000"
+englishNumbers.forEach((num, i) => {
+  test(
+    'Understands english number ' + num,
+    macro,
+    num + ' seconds',
+    (i + 1) * units.second
+  );
+});
+
+// Understands negative numbers
+// i.e. "-2 seconds === -2000"
+timeUnits.forEach(unit => {
+  test(
+    'Understands negative ' + unit + 's',
+    macro,
+    '-2 ' + unit + 's',
+    -2 * Number(units[unit])
+  );
+});
+
+// Mixed
+test('Understands mixed units', macro, '3 minutes and 30 seconds', (3 * units.minute) + (30 * units.second));
+test('Understands mixed time expressions', macro, ['three minutes and 30 seconds', 'three minutes 30 seconds'], (3 * units.minute) + (30 * units.second));
 test('Understands 2 digit english numbers', macro, 'thirty three seconds', 33 * units.second);
-test('mix units + multi digit english numbers', macro, 'hundred and three seconds and twelve minutes', (103 * units.second) + (12 * units.minute));
+test('Understands mix units + multi digit english numbers', macro, 'hundred and three seconds and twelve minutes', (103 * units.second) + (12 * units.minute));
+test('Understands hyphenated numbers', macro, 'three hundred and twenty-five seconds', (325 * units.second));


### PR DESCRIPTION
Refactor human interval using [numbered](https://www.npmjs.com/package/numbered) package

- Supports numbers written as english words
- Supports negative numbers
- Supports hyphenated words
- Added more tests to verify the functionality 
- Updated README.md

Closes #9 
Updated after pulling changes from #19 