### PR TITLE
Refactor to use node-numbered

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,7 @@ Human Interval supports the following units
 
 ### Wordy Numbers
 
-Human Interval supports numbers up to ten being written out in English. If you
-want to extend it, you can do so by adding more keys to the language map.
-Alternatively you could add support for alternative languages.
-
-```js
-const humanInterval = require('human-interval');
-humanInterval.languageMap['one-hundred'] = 100
-
-// Adds support for the following:
-humanInterval('one-hundred and fifty seconds') // returns 150000
-```
+Human Interval supports English numbers being written out in English by using [node-numbered](https://github.com/blakeembrey/node-numbered).
 
 # License
 [The MIT License](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Human Interval
-Human readable interval parser for Javascript.
+Human-readable interval parser for Javascript.
 
-Heavily inspired by
-[matthewmueller/date](http://github.com/matthewmueller/date).
+Converts words written in English to numbers by using [node-numbered](https://github.com/blakeembrey/node-numbered).
 
-This package converts words written in english to numbers by using [node-numbered](https://github.com/blakeembrey/node-numbered).
+Originally inspired by [matthewmueller/date](http://github.com/matthewmueller/date).
 
+## Uses
+
+Human Interval is used by job scheduling libraries such as [Agenda](https://github.com/Agenda/agenda#readme) and [Bree](https://jobscheduler.net). They are a job schedulers for Node.js with cron expression syntax, human-friendly times, Dates, and more!
 
 ## Example Usage
 
@@ -13,9 +15,8 @@ This package converts words written in english to numbers by using [node-numbere
 const humanInterval = require('human-interval');
 
 setTimeout(() => {
-  // Do something crazy!
+  // Do something!
 }, humanInterval('three minutes'));
-
 ```
 
 ## More sophisticated examples
@@ -33,37 +34,37 @@ humanInterval('4 months, 3 days, 5 hours and forty-five seconds');
 
 ## The full list
 
-### Supported Units
+### Units
 
-Human Interval supports the following units
+Supports the following units in the plural and singular forms:
 
 - `seconds`
 - `minutes`
 - `hours`
 - `days`
 - `weeks`
-- `months` -- assumes 30 days
-- `years` -- assumes 365 days
+- `months` — assumes 30 days
+- `years` — assumes 365 days
 
-### Wordy Numbers
+### Wordy numbers
 
-Human Interval supports numbers being written out in English words.
+Supports numbers being written out in English words.
 
 ```js
 humanInterval('five minutes');
 ```
 
-### Hyphenated Numbers
+### Hyphenated numbers
 
-Human Interval supports hyphenated numbers.
+Supports hyphenated numbers.
 
 ```js
 humanInterval('twenty-five seconds');
 ```
 
-### Negative Numbers
+### Negative numbers
 
-Human Interval supports negative numbers if the time starts with a `-` symbol immediately followed by a number.
+Supports negative numbers if the time starts with a `-` symbol immediately followed by a number.
 
 ```js
 humanInterval('-2 minutes');

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Human readable interval parser for Javascript.
 Heavily inspired by
 [matthewmueller/date](http://github.com/matthewmueller/date).
 
-**If you'd like to use this for job scheduling, then check out [Bree](https://jobscheduler.net).  Bree is a job scheduler for Node.js with built-in support for workers, cron expression syntax, human-friendly times, Dates, and more.**
+This package converts words written in english to numbers by using [node-numbered](https://github.com/blakeembrey/node-numbered).
+
 
 ## Example Usage
 
@@ -22,10 +23,12 @@ setTimeout(() => {
 Human Interval understands all of the following examples:
 
 ```js
+humanInterval('minute');
 humanInterval('one minute');
 humanInterval('1.5 minutes');
 humanInterval('3 days and 4 hours');
 humanInterval('3 days, 4 hours and 36 seconds');
+humanInterval('4 months, 3 days, 5 hours and forty-five seconds');
 ```
 
 ## The full list
@@ -44,7 +47,27 @@ Human Interval supports the following units
 
 ### Wordy Numbers
 
-Human Interval supports English numbers being written out in English by using [node-numbered](https://github.com/blakeembrey/node-numbered).
+Human Interval supports numbers being written out in English words.
+
+```js
+humanInterval('five minutes');
+```
+
+### Hyphenated Numbers
+
+Human Interval supports hyphenated numbers.
+
+```js
+humanInterval('twenty-five seconds');
+```
+
+### Negative Numbers
+
+Human Interval supports negative numbers if the time starts with a `-` symbol immediately followed by a number.
+
+```js
+humanInterval('-2 minutes');
+```
 
 # License
 [The MIT License](LICENSE.md)

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const numbered = require('numbered');
+
 const units = {};
 units.second = 1000;
 units.minute = units.second * 60;
@@ -7,62 +9,40 @@ units.week = units.day * 7;
 units.month = units.day * 30;
 units.year = units.day * 365;
 
-const languageMap = {
-  one: 1,
-  two: 2,
-  three: 3,
-  four: 4,
-  five: 5,
-  six: 6,
-  seven: 7,
-  eight: 8,
-  nine: 9,
-  ten: 10
-};
-
-const swapLanguageToDecimals = time => {
-  const language = languageMap;
-  const languageMapRegex = new RegExp('(' + Object.keys(language).join('|') + ')', 'g');
-  const matches = time.match(languageMapRegex);
-  if (!matches) {
-    return time;
-  }
-
-  matches.forEach(match => {
-    const matchString = language[match] > 1 ? language[match] : language[match].toString().slice(1);
-    time = time.replace(match, matchString);
-  });
-  return time;
-};
-
-const processUnits = time => {
-  if (time.match(/(second|minute|hour|day|week|month|year)s?/) === null) {
-    return undefined;
-  }
-
-  const number = Number.parseFloat(time) || 1;
-  const unit = time.match(/(second|minute|hour|day|week|month|year)s?/)[1];
-
-  return units[unit] * number;
-};
+const regexp = /(second|minute|hour|day|week|month|year)s?/;
 
 const humanInterval = time => {
-  if (!time) {
+  if (!time || typeof time === 'number') {
     return time;
   }
 
-  if (typeof time === 'number') {
-    return time;
-  }
+  let result = NaN;
 
-  time = swapLanguageToDecimals(time);
-  time = time.replace(/(second|minute|hour|day|week|month|year)s?(?! ?(s )?and |s?$)/, '$1,');
-  // eslint-disable-next-line unicorn/no-reduce
-  return time.split(/and|,/).reduce((sum, group) => {
-    return sum + (group ? processUnits(group) : 0);
-  }, 0);
+  time = time.replace(/([^a-z0-9.-]|and)+/g, ' ');
+
+  for (;;) {
+    const match = time.match(regexp);
+    if (!match) {
+      return result;
+    }
+
+    const matchedNumber = time.slice(0, match.index).trim();
+    const unit = units[match[1]];
+    let number = 1;
+    if (matchedNumber.length !== 0) {
+      number = parseFloat(matchedNumber);
+      if (isNaN(number)) {
+        number = numbered.parse(matchedNumber);
+      }
+    }
+
+    if (isNaN(result)) {
+      result = 0;
+    }
+
+    result += number * unit;
+    time = time.slice(match.index + match[0].length);
+  }
 };
-
-humanInterval.languageMap = languageMap;
 
 module.exports = humanInterval;

--- a/index.js
+++ b/index.js
@@ -16,9 +16,9 @@ const humanInterval = time => {
     return time;
   }
 
-  let result = NaN;
+  let result = Number.NaN;
 
-  time = time.replace(/([^a-z0-9.-]|and)+/g, ' ');
+  time = time.replace(/([^a-z\d.-]|and)+/g, ' ');
 
   for (;;) {
     const match = time.match(regexp);
@@ -30,13 +30,13 @@ const humanInterval = time => {
     const unit = units[match[1]];
     let number = 1;
     if (matchedNumber.length !== 0) {
-      number = parseFloat(matchedNumber);
-      if (isNaN(number)) {
+      number = Number.parseFloat(matchedNumber);
+      if (Number.isNaN(number)) {
         number = numbered.parse(matchedNumber);
       }
     }
 
-    if (isNaN(result)) {
+    if (Number.isNaN(result)) {
       result = 0;
     }
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "bugs": {
     "url": "https://github.com/agenda/human-interval/issues"
   },
+  "dependencies": {
+    "numbered": "^1.1.0"
+  },
   "devDependencies": {
     "ava": "3.13.0",
     "xo": "0.33.1"

--- a/test.js
+++ b/test.js
@@ -42,7 +42,7 @@ const englishNumbers = [
 test('Returns undefined when given undefined', macro, undefined, undefined);
 test('Returns null when given null', macro, null, null);
 test('Returns empty string when given empty string', macro, '', '');
-test('Returns NaN when given unknown string', macro, 'foobar', Number.NaN);
+test('Returns NaN when given unknown string', macro, 'foobar', NaN);
 
 // Single values
 test('Returns the number when given a number', macro, 5000, 5000);
@@ -96,16 +96,30 @@ timeUnits.forEach(unit => {
 
 // English numbers
 // i.e. "one second === 1000"
-englishNumbers.forEach((number, i) => {
+englishNumbers.forEach((num, i) => {
   test(
-    'Understands english number ' + number,
+    'Understands english number ' + num,
     macro,
-    number + ' seconds',
+    num + ' seconds',
     (i + 1) * units.second
   );
 });
 
+// Understands negative numbers
+// i.e. "-2 seconds === -2000"
+timeUnits.forEach(unit => {
+  test(
+    'Understands negative ' + unit + 's',
+    macro,
+    '-2 ' + unit + 's',
+    -2 * Number(units[unit])
+  );
+});
+
 // Mixed
-test('Works with mixed units in plural units', macro, ['3 minutes and 30 seconds', '3 minutes 30 seconds'], (3 * units.minute) + (30 * units.second));
-test('Works with mixed units in singular units', macro, ['1 minute and 1 second', '1 minute 1 second'], units.minute + units.second);
-test('Works with mixed time expressions', macro, ['three minutes and 30 seconds', 'three minutes 30 seconds'], (3 * units.minute) + (30 * units.second));
+test('Understands mixed units', macro, '3 minutes and 30 seconds', (3 * units.minute) + (30 * units.second));
+test('Understands mixed time expressions with plurals', macro, ['three minutes and 30 seconds', 'three minutes 30 seconds'], (3 * units.minute) + (30 * units.second));
+test('Understands mixed time expressions with singulars', macro, ['one minute and 1 second', 'one minute 1 second'], units.minute + units.second);
+test('Understands 2 digit english numbers', macro, 'thirty three seconds', 33 * units.second);
+test('Understands mix units + multi digit english numbers', macro, 'hundred and three seconds and twelve minutes', (103 * units.second) + (12 * units.minute));
+test('Understands hyphenated numbers', macro, 'three hundred and twenty-five seconds', (325 * units.second));

--- a/test.js
+++ b/test.js
@@ -42,7 +42,7 @@ const englishNumbers = [
 test('Returns undefined when given undefined', macro, undefined, undefined);
 test('Returns null when given null', macro, null, null);
 test('Returns empty string when given empty string', macro, '', '');
-test('Returns NaN when given unknown string', macro, 'foobar', NaN);
+test('Returns NaN when given unknown string', macro, 'foobar', Number.NaN);
 
 // Single values
 test('Returns the number when given a number', macro, 5000, 5000);
@@ -96,11 +96,11 @@ timeUnits.forEach(unit => {
 
 // English numbers
 // i.e. "one second === 1000"
-englishNumbers.forEach((num, i) => {
+englishNumbers.forEach((number, i) => {
   test(
-    'Understands english number ' + num,
+    'Understands english number ' + number,
     macro,
-    num + ' seconds',
+    number + ' seconds',
     (i + 1) * units.second
   );
 });


### PR DESCRIPTION
Rebased https://github.com/agenda/human-interval/pull/33 — kudos @sampathBlam for the work there and @alFReD-NSH working on this originally in  https://github.com/agenda/human-interval/pull/19

> Refactor human interval using [numbered](https://www.npmjs.com/package/numbered) package
> 
> - Supports numbers written as english words
> - Supports negative numbers
> - Supports hyphenated words
> - Added more tests to verify the functionality 
> - Updated README.md

Closes #9 